### PR TITLE
Added support for std::map, and fixed bugs

### DIFF
--- a/SerializationMacros.hpp
+++ b/SerializationMacros.hpp
@@ -169,12 +169,12 @@
 #define DEFAULT_DESERIALIZE2(Name,a)									\
 	static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* p, char const * v){ \
 		auto a2 = mutils::from_bytes<std::decay_t<decltype(a)> >(p,v);	\
-		return make_unique<Name>(*a2);									\
+		return std::make_unique<Name>(*a2);									\
 	}
 #define DEFAULT_DESERIALIZE3(Name,a,b)									\
 	static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* p, char const * v){		\
 		auto a2 = mutils::from_bytes<std::decay_t<decltype(a)> >(p,v);	\
-		return make_unique<Name>(*a2,*(mutils::from_bytes<std::decay_t<decltype(b)> >(p,v + mutils::bytes_size(*a2)))); \
+		return std::make_unique<Name>(*a2,*(mutils::from_bytes<std::decay_t<decltype(b)> >(p,v + mutils::bytes_size(*a2)))); \
 	}
 #define DEFAULT_DESERIALIZE4(Name,a,b,c)								\
 	static std::unique_ptr<Name> from_bytes(mutils::DeserializationManager* p, char const * v){					\


### PR DESCRIPTION
* DEFAULT_DESERIALIZE2 forgot to qualify make_unqiue with std::,
  resulting in compilation errors if DEFAULT_SERIALIZATION_SUPPORT was
  used on a class with only one field
* to_bytes for std::pair neglected to actually write the serialized pair
  to the provided buffer
* Minor improvements to STL deserializers, using from_bytes_noalloc for
  elements that are copied into the container anyway